### PR TITLE
Support fully qualified names in input model

### DIFF
--- a/src/dotnet/ReSharperPlugin.SharpCoachPlugin.Core/Providers/FunctionInfoProviders/Abstractions/FunctionInfoProviderBase.cs
+++ b/src/dotnet/ReSharperPlugin.SharpCoachPlugin.Core/Providers/FunctionInfoProviders/Abstractions/FunctionInfoProviderBase.cs
@@ -29,8 +29,14 @@ namespace ReSharperPlugin.SharpCoachPlugin.Core.Providers.FunctionInfoProviders.
 
         public ClassTypeInfoProvider GetArgumentTypeDeclaration(int index)
         {
-            var argument = ParameterList.FindNodeAt(new TreeTextRange(new TreeOffset(index)));
-            var argumentReferenceName = argument?.Parent as IReferenceName;
+            /* Structure:
+             * - IndexedArgument is a RegularParameterDeclaration
+             *   - FirstChild is UserTypeUsage
+             *     - FirstChild is ReferenceName, containing IDENTIFIER over user fully qualified user type 
+             */
+            
+            var indexedArgument = ParameterList.Children().ElementAt(index);
+            var argumentReferenceName = indexedArgument.FirstChild?.FirstChild as IReferenceName;
 
             var classDeclaration = argumentReferenceName?.Reference.Resolve();
             var parameter = ParameterList.Children().ElementAt(index) as IParameterDeclaration;

--- a/src/dotnet/ReSharperPlugin.SharpCoachPlugin.Tests/ReSharperPlugin.SharpCoachPlugin.Tests.csproj
+++ b/src/dotnet/ReSharperPlugin.SharpCoachPlugin.Tests/ReSharperPlugin.SharpCoachPlugin.Tests.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <Compile Remove="test/**/*" />
+    <Compile Include="test\src\Actions\FullModelNameTests.cs" />
     <Compile Include="test\src\Actions\MapClassInternalsTests.cs" />
     <Compile Include="test\src\Actions\MapCollectionInternalsTests.cs" />
     <Compile Include="test\src\Actions\MapEnumInternalsTests.cs" />

--- a/src/dotnet/ReSharperPlugin.SharpCoachPlugin.Tests/test/data/Intentions/ContextActions/Actions/FullModelNameTests/FullInputModelNameTest.cs
+++ b/src/dotnet/ReSharperPlugin.SharpCoachPlugin.Tests/test/data/Intentions/ContextActions/Actions/FullModelNameTests/FullInputModelNameTest.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Library.Models.Mapping 
+{
+    public class FullInputModelNameTest
+    {
+        static UserResponse ToResponse{caret}(Library.Models.Mapping.UserRequest request)
+    }
+
+    public class UserRequest
+    {
+        public int Prop { get; set; }
+    }
+
+    public class UserResponse
+    {
+        public int Prop { get; set; }
+    }
+}

--- a/src/dotnet/ReSharperPlugin.SharpCoachPlugin.Tests/test/data/Intentions/ContextActions/Actions/FullModelNameTests/FullInputModelNameTest.cs.gold
+++ b/src/dotnet/ReSharperPlugin.SharpCoachPlugin.Tests/test/data/Intentions/ContextActions/Actions/FullModelNameTests/FullInputModelNameTest.cs.gold
@@ -1,0 +1,22 @@
+using System;
+
+namespace Library.Models.Mapping 
+{
+    public class FullInputModelNameTest
+    {
+        static UserResponse ToResponse{caret}(Library.Models.Mapping.UserRequest request)
+        {
+          return new UserResponse() {Prop = request.Prop};
+        }
+    }
+
+    public class UserRequest
+    {
+        public int Prop { get; set; }
+    }
+
+    public class UserResponse
+    {
+        public int Prop { get; set; }
+    }
+}

--- a/src/dotnet/ReSharperPlugin.SharpCoachPlugin.Tests/test/data/Intentions/ContextActions/Actions/FullModelNameTests/FullOutputModelNameTest.cs
+++ b/src/dotnet/ReSharperPlugin.SharpCoachPlugin.Tests/test/data/Intentions/ContextActions/Actions/FullModelNameTests/FullOutputModelNameTest.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Library.Models.Mapping 
+{
+    public class FullOutputModelNameTest
+    {
+        static Library.Models.Mapping.UserResponse ToResponse{caret}(UserRequest request)
+    }
+
+    public class UserRequest
+    {
+        public int Prop { get; set; }
+    }
+
+    public class UserResponse
+    {
+        public int Prop { get; set; }
+    }
+}

--- a/src/dotnet/ReSharperPlugin.SharpCoachPlugin.Tests/test/data/Intentions/ContextActions/Actions/FullModelNameTests/FullOutputModelNameTest.cs.gold
+++ b/src/dotnet/ReSharperPlugin.SharpCoachPlugin.Tests/test/data/Intentions/ContextActions/Actions/FullModelNameTests/FullOutputModelNameTest.cs.gold
@@ -1,0 +1,22 @@
+using System;
+
+namespace Library.Models.Mapping 
+{
+    public class FullOutputModelNameTest
+    {
+        static Library.Models.Mapping.UserResponse ToResponse{caret}(UserRequest request)
+        {
+          return new UserResponse() {Prop = request.Prop};
+        }
+    }
+
+    public class UserRequest
+    {
+        public int Prop { get; set; }
+    }
+
+    public class UserResponse
+    {
+        public int Prop { get; set; }
+    }
+}

--- a/src/dotnet/ReSharperPlugin.SharpCoachPlugin.Tests/test/src/Actions/FullModelNameTests.cs
+++ b/src/dotnet/ReSharperPlugin.SharpCoachPlugin.Tests/test/src/Actions/FullModelNameTests.cs
@@ -1,0 +1,17 @@
+using JetBrains.ReSharper.FeaturesTestFramework.Intentions;
+using NUnit.Framework;
+using ReSharperPlugin.SharpCoachPlugin.Actions;
+
+namespace ReSharperPlugin.SharpCoachPlugin.Tests.test.src.Actions
+{
+    public class FullModelNameTests : CSharpContextActionExecuteTestBase<MapModelsAction>
+    {
+        protected override string ExtraPath => @"Actions\FullModelNameTests";
+
+        [Test]
+        public void TestFullInputModelNameTest() { DoNamedTest2(); }
+        
+        [Test]
+        public void TestFullOutputModelNameTest() { DoNamedTest2(); }
+    }
+}


### PR DESCRIPTION
Supported fully qualified names for generation
```
static Response Convert(Fully.Qualified.Name.Request request) => ...
```

Closes #8 