### PR TITLE
remove testDotNet on publish of plugin task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,16 +82,6 @@ task compileDotNet {
     }
 }
 
-task testDotNet {
-    doLast {
-        exec {
-            executable "dotnet"
-            args "test","${DotnetSolution}","--logger","GitHubActions"
-            workingDir rootDir
-        }
-    }
-}
-
 buildPlugin {
     doLast {
         copy {
@@ -211,7 +201,6 @@ prepareSandbox {
 }
 
 publishPlugin {
-    dependsOn testDotNet
     dependsOn buildPlugin
     token = "${PublishToken}"
 


### PR DESCRIPTION
there is no need to test dotnet sln using githubactions (wtf, jetbrains) before publish. we have a CI\CD in repo for that